### PR TITLE
do not add d3 to window when exporting using define

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -6823,5 +6823,5 @@
   d3.xml = d3_xhrType(function(request) {
     return request.responseXML;
   });
-  if (typeof define === "function" && define.amd) this.d3 = d3, define(d3); else if (typeof module === "object" && module.exports) module.exports = d3; else this.d3 = d3;
+  if (typeof define === "function" && define.amd) define(d3); else if (typeof module === "object" && module.exports) module.exports = d3; else this.d3 = d3;
 }.apply(self);

--- a/src/end.js
+++ b/src/end.js
@@ -1,4 +1,4 @@
-  if (typeof define === "function" && define.amd) this.d3 = d3, define(d3);
+  if (typeof define === "function" && define.amd) define(d3);
   else if (typeof module === "object" && module.exports) module.exports = d3;
   else this.d3 = d3;
 }.apply(self);


### PR DESCRIPTION
Fixing https://github.com/plotly/plotly.js/issues/6483.
