### PR TITLE
Fix unicode variable names

### DIFF
--- a/src/geom/voronoi/cell.js
+++ b/src/geom/voronoi/cell.js
@@ -1,6 +1,6 @@
 import "../../math/abs";
 
-function d3_geom_voronoiCell(site) {
+function d3_geom_voronoiCell(site) {
   this.site = site;
   this.edges = [];
 }

--- a/src/math/random.js
+++ b/src/math/random.js
@@ -1,8 +1,8 @@
 d3.random = {
-  normal: function(µ, σ) {
+  normal: function(mu, sigma) {
     var n = arguments.length;
-    if (n < 2) σ = 1;
-    if (n < 1) µ = 0;
+    if (n < 2) sigma = 1;
+    if (n < 1) mu = 0;
     return function() {
       var x, y, r;
       do {
@@ -10,7 +10,7 @@ d3.random = {
         y = Math.random() * 2 - 1;
         r = x * x + y * y;
       } while (!r || r > 1);
-      return µ + σ * x * Math.sqrt(-2 * Math.log(r) / r);
+      return mu + sigma * x * Math.sqrt(-2 * Math.log(r) / r);
     };
   },
   logNormal: function() {


### PR DESCRIPTION
Our tooling (parcel) doesn't like the Unicode variable names and refuses to build Plotly because of this code.

I've already opened an issue with Parcel [here](https://github.com/parcel-bundler/parcel/issues/9695), but maybe this is the quicker fix.